### PR TITLE
Migrate to RxJava 3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {
@@ -30,7 +39,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0-alpha09'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.13'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.6'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/java/at/allaboutapps/inappupdaterdemo/ForceUpdateDemoActivity.kt
+++ b/app/src/main/java/at/allaboutapps/inappupdaterdemo/ForceUpdateDemoActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import at.allaboutapps.inappupdater.InAppUpdateManager
 import at.allaboutapps.inappupdater.InAppUpdateStatus
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.disposables.Disposable
 
 class ForceUpdateDemoActivity : AppCompatActivity() {
 
@@ -15,7 +15,7 @@ class ForceUpdateDemoActivity : AppCompatActivity() {
     }
 
     private lateinit var inAppUpdateManager: InAppUpdateManager
-    private var inAppUpdateStatusDisposable = Disposables.empty()
+    private var inAppUpdateStatusDisposable = Disposable.empty()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/at/allaboutapps/inappupdaterdemo/UpdateTypeDemoActivity.kt
+++ b/app/src/main/java/at/allaboutapps/inappupdaterdemo/UpdateTypeDemoActivity.kt
@@ -7,7 +7,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import at.allaboutapps.inappupdater.InAppUpdateManager
 import at.allaboutapps.inappupdater.InAppUpdateStatus
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.disposables.Disposable
 import kotlinx.android.synthetic.main.activity_update_type.*
 
 class UpdateTypeDemoActivity : AppCompatActivity() {
@@ -17,7 +17,7 @@ class UpdateTypeDemoActivity : AppCompatActivity() {
     }
 
     private lateinit var inAppUpdateManager: InAppUpdateManager
-    private var inAppUpdateStatusDisposable = Disposables.empty()
+    private var inAppUpdateStatusDisposable = Disposable.empty()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/inappupdater/build.gradle
+++ b/inappupdater/build.gradle
@@ -34,6 +34,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 bintray {
@@ -129,7 +138,7 @@ dependencies {
     implementation 'com.google.android.play:core:1.6.3'
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.13'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.6'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/inappupdater/src/main/java/at/allaboutapps/inappupdater/InAppUpdateManager.kt
+++ b/inappupdater/src/main/java/at/allaboutapps/inappupdater/InAppUpdateManager.kt
@@ -9,8 +9,8 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
-import io.reactivex.Observable
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.Disposable
 
 /**
  * InAppUpdateManager handles the in app update process
@@ -55,7 +55,7 @@ class InAppUpdateManager(
             appUpdateManager.registerListener(updateStateListener)
 
             // unregister listener on dispose
-            emitter.setDisposable(Disposables.fromAction {
+            emitter.setDisposable(Disposable.fromAction {
                 appUpdateManager.unregisterListener(
                     updateStateListener
                 )


### PR DESCRIPTION
This contains the migration of A3InAppUpdater to RxJava 3.

---

When I tried this (copied `inappupdater/build/outputs/aar/a3inappupdater-release.aar` to my project and using that dependency) then I get the following crash:

```
     Caused by: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/google/android/play/core/appupdate/AppUpdateManagerFactory;
        at at.allaboutapps.inappupdater.InAppUpdateManager.<init>(InAppUpdateManager.kt:32)
        at com.example.features.start.MainActivity.initInAppUpdate(MainActivity.kt:158)
        at com.example.features.start.MainActivity.access$initInAppUpdate(MainActivity.kt:45)
        at com.example.features.start.MainActivity$onCreate$2.accept(MainActivity.kt:107)
        at com.example.features.start.MainActivity$onCreate$2.accept(MainActivity.kt:45)
        at io.reactivex.rxjava3.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63)
        at io.reactivex.rxjava3.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal(ObservableObserveOn.java:201)
        at io.reactivex.rxjava3.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run(ObservableObserveOn.java:255)
        at io.reactivex.rxjava3.android.schedulers.HandlerScheduler$ScheduledRunnable.run(HandlerScheduler.java:123)
        at android.os.Handler.handleCallback(Handler.java:883) 
        at android.os.Handler.dispatchMessage(Handler.java:100) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7682) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950) 
     Caused by: java.lang.ClassNotFoundException: Didn't find class "com.google.android.play.core.appupdate.AppUpdateManagerFactory" on path: DexPathList[[zip file "/data/app/com.example-ACWo4UFPedc2ME-89dhpQg==/base.apk"],nativeLibraryDirectories=[/data/app/com.example-ACWo4UFPedc2ME-89dhpQg==/lib/arm64, /system/lib64, /system/product/lib64]]
        at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:196)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
        at at.allaboutapps.inappupdater.InAppUpdateManager.<init>(InAppUpdateManager.kt:32) 
        at com.example.features.start.MainActivity.initInAppUpdate(MainActivity.kt:158) 
        at com.example.features.start.MainActivity.access$initInAppUpdate(MainActivity.kt:45) 
        at com.example.features.start.MainActivity$onCreate$2.accept(MainActivity.kt:107) 
        at com.example.features.start.MainActivity$onCreate$2.accept(MainActivity.kt:45) 
        at io.reactivex.rxjava3.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63) 
        at io.reactivex.rxjava3.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal(ObservableObserveOn.java:201) 
        at io.reactivex.rxjava3.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run(ObservableObserveOn.java:255) 
        at io.reactivex.rxjava3.android.schedulers.HandlerScheduler$ScheduledRunnable.run(HandlerScheduler.java:123) 
        at android.os.Handler.handleCallback(Handler.java:883) 
        at android.os.Handler.dispatchMessage(Handler.java:100) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7682) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950) 
```

I'm hoping this is just caused by my local aar build?